### PR TITLE
`DecisionTree`, `DecisionForest`, `MixedModels`: dispatches tidying, adding exports and docstrings

### DIFF
--- a/src/types/model.jl
+++ b/src/types/model.jl
@@ -35,6 +35,7 @@ Symbolic models can wrap other `AbstractModel`s, and use them to compute the out
 As such, an `AbstractModel` can actually be the result of a composition of many models,
 and enclose a *tree* of `AbstractModel`s (with `LeafModel`s at the leaves).
 
+# TODO - bring missing dispatches here (do the same for other model types)
 # Interface
 - `isopen(m::AbstractModel)`
 - `apply(m::AbstractModel, i::AbstractInterpretation; kwargs...)`


### PR DESCRIPTION
This pull request is the natural continuation of #30, given that the file `base.jl` (containing abstract and concrete definitions of various models) is now split into `types/model.jl` and (in `utils/models/`) `leaf.jl`, `rule-and-branch.jl` and `other.jl`.

In particular, me and @Michele21 refined the docstrings for `DecisionTree`, `DecisionForest` and `MixedModel`.
We added the missing exports to `SoleModels.jl` and we fixed a repeated dispatch (`apply` for `DecisionTree`).