### PR TITLE
New bestguess from SoleBase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - xgboost_regressor
+      - new_bestguess
     tags: ['*']
   pull_request:
   workflow_dispatch:

--- a/ext/DecisionTreeExt.jl
+++ b/ext/DecisionTreeExt.jl
@@ -99,9 +99,9 @@ function SoleModels.solemodel(
     # end
 
     if isnothing(weights)
-        m = DecisionEnsemble{O}(trees, info)
+        m = DecisionEnsemble{O}(trees, info; parity_func=x->first(sort(collect(keys(x)))))
     else
-        m = DecisionEnsemble{O}(trees, weights, info)
+        m = DecisionEnsemble{O}(trees, weights, info; parity_func=x->first(sort(collect(keys(x)))))
     end
     return m
 end

--- a/ext/XGBoostExt.jl
+++ b/ext/XGBoostExt.jl
@@ -150,10 +150,10 @@ function SoleModels.solemodel(
 )
     keep_condensed && error("Cannot keep condensed XGBoost.Node.")
 
-    classlabels === nothing || (nclasses = length(classlabels))
+    isnothing(classlabels) || (nclasses = length(classlabels))
 
     trees = map(enumerate(model)) do (i, t)
-        classlabels === nothing ? begin
+        isnothing(classlabels) ? begin
             class_idx = nothing
             clabels = nothing
         end : begin
@@ -239,7 +239,7 @@ function xgbleaf(
     classlabels=nothing,
     use_float32::Bool,
 )
-    if classlabels === nothing
+    if isnothing(classlabels)
         # regression
         prediction = use_float32 ? Float32(leaf.leaf) : leaf.leaf
     else
@@ -249,7 +249,7 @@ function xgbleaf(
         !any(bitX) && (bitX = trues(length(y)))
         prediction = SoleModels.bestguess(y[bitX]; suppress_parity_warning=true)
 
-        prediction === nothing && return nothing
+        isnothing(prediction) && return nothing
     end
 
     leaf_value = use_float32 ? Float32(leaf.leaf) : leaf.leaf

--- a/src/utils/models/ensembles.jl
+++ b/src/utils/models/ensembles.jl
@@ -31,18 +31,19 @@ struct DecisionEnsemble{O,T<:AbstractModel,A<:Base.Callable,W<:Union{Nothing,Abs
         aggregation::Union{Nothing,Base.Callable},
         weights::Union{Nothing,AbstractVector},
         info::NamedTuple = (;);
-        suppress_parity_warning = nothing,
+        suppress_parity_warning=false,
+        parity_func=x->argmax(x)
     ) where {O,T<:AbstractModel}
         @assert length(models) > 0 "Cannot instantiate empty ensemble!"
         models = wrap.(models)
         if isnothing(aggregation)
             # if a suppress_parity_warning parameter is provided, then the aggregation's suppress_parity_warning defaults to it;
             #  otherwise, it defaults to bestguess's suppress_parity_warning
-            if isnothing(suppress_parity_warning)
-                aggregation = function (args...; kwargs...) bestguess(args...; kwargs...) end
-            else
-                aggregation = function (args...; suppress_parity_warning = suppress_parity_warning, kwargs...) bestguess(args...; suppress_parity_warning, kwargs...) end
-            end
+            # if isnothing(suppress_parity_warning)
+            #     aggregation = function (args...; kwargs...) bestguess(args...; suppress_parity_warning, parity_func, kwargs...) end
+            # else
+                aggregation = function (args...; suppress_parity_warning, kwargs...) bestguess(args...; suppress_parity_warning, parity_func, kwargs...) end
+            # end
         else
             isnothing(suppress_parity_warning) || @warn "Unexpected value for suppress_parity_warning: $(suppress_parity_warning)."
         end

--- a/src/utils/models/ensembles.jl
+++ b/src/utils/models/ensembles.jl
@@ -45,7 +45,7 @@ struct DecisionEnsemble{O,T<:AbstractModel,A<:Base.Callable,W<:Union{Nothing,Abs
                 aggregation = function (args...; suppress_parity_warning, kwargs...) bestguess(args...; suppress_parity_warning, parity_func, kwargs...) end
             # end
         else
-            isnothing(suppress_parity_warning) || @warn "Unexpected value for suppress_parity_warning: $(suppress_parity_warning)."
+            !suppress_parity_warning || @warn "Unexpected value for suppress_parity_warning: $(suppress_parity_warning)."
         end
         # T = typeof(models)
         W = typeof(weights)

--- a/test/DecisionTreeExt/adaboost.jl
+++ b/test/DecisionTreeExt/adaboost.jl
@@ -101,8 +101,8 @@ println("RandomForest accuracy: ", rm_accuracy)
 @testset "data validation" begin
     Stump = MLJ.@load AdaBoostStumpClassifier pkg=DecisionTree
 
-    for train_ratio in 0.5:0.1:0.9
-        for seed in 1:40
+    for train_ratio in 0.7:0.1:0.9
+        for seed in 1:10
             train, test = partition(eachindex(y), train_ratio; shuffle=true, rng=Xoshiro(seed))
             X_train, y_train = X[train, :], y[train]
             X_test, y_test = X[test, :], y[test]

--- a/test/DecisionTreeExt/tree.jl
+++ b/test/DecisionTreeExt/tree.jl
@@ -70,13 +70,13 @@ printmodel.(sort(interesting_rules, by = readmetrics); show_metrics = (; round_d
 @testset "data validation" begin
     Tree = MLJ.@load DecisionTreeClassifier pkg=DecisionTree
 
-    for train_ratio in 0.5:0.1:0.9
-        for seed in 1:40
+    for train_ratio in 0.7:0.1:0.9
+        for seed in 1:10
             train, test = partition(eachindex(y), train_ratio; shuffle=true, rng=Xoshiro(seed))
             X_train, y_train = X[train, :], y[train]
             X_test, y_test = X[test, :], y[test]
 
-            for max_depth in 2:1:6
+            for max_depth in 3:1:6
                 # solemodel
                 model = Tree(; max_depth, rng=Xoshiro(seed))
                 mach = machine(model, X_train, y_train)

--- a/test/XGBoostExt/xgboost_classifier.jl
+++ b/test/XGBoostExt/xgboost_classifier.jl
@@ -111,14 +111,14 @@ println("RandomForest accuracy: ", rm_accuracy)
 @testset "data validation" begin
     XGTrees = MLJ.@load XGBoostClassifier pkg=XGBoost
 
-    for train_ratio in 0.5:0.1:0.9
-        for seed in 1:40
+    for train_ratio in 0.7:0.1:0.9
+        for seed in 1:10
             train, test = partition(eachindex(y), train_ratio; shuffle=true, rng=Xoshiro(seed))
             X_train, y_train = X[train, :], y[train]
             X_test, y_test = X[test, :], y[test]
 
-            for num_round in 10:10:50
-                for eta in 0.1:0.1:0.6
+            for num_round in 10:10:20
+                for eta in 0.1:0.1:0.3
                     model = XGTrees(; num_round, eta, objective="multi:softmax")
                     mach = machine(model, X_train, y_train)
                     fit!(mach, verbosity=0)

--- a/test/XGBoostExt/xgboost_regressor.jl
+++ b/test/XGBoostExt/xgboost_regressor.jl
@@ -57,15 +57,15 @@ preds = apply!(solem, X_test_f32, y_test; base_score)
 @testset "data validation" begin
     XGTrees = MLJ.@load XGBoostRegressor pkg=XGBoost verbosity=0
 
-    for train_ratio in 0.6:0.1:0.9
-        for seed in 1:40
+    for train_ratio in 0.7:0.1:0.9
+        for seed in 1:10
             train, test = partition(eachindex(y), train_ratio; shuffle=true, rng=Xoshiro(seed))
             X_train, y_train = X[train, :], y[train]
             X_test, y_test = X[test, :], y[test]
             base_score = mean(y_train)
 
-            for num_round in 10:10:50
-                for max_depth in 2:6
+            for num_round in 10:10:20
+                for max_depth in 3:6
                     model = XGTrees(; num_round, max_depth, objective="reg:squarederror")
                     mach = machine(model, X_train, y_train)
                     mach.model.base_score = base_score


### PR DESCRIPTION
Now it's possible to pass custom bestguess function in case of tie parity.
We choose to add the same tie parity policy that uses MLJ to our DecisionEnsemble.
Important note:
while MLJ choose, in case of parity, the first one in alphabetical order, DecisionTree package choose the very first one, without soting them first.
We choose to stay close to MLJ policy, but we are open for future thoughts: this is why we adopt the 'user custom function' approach.