### PR TITLE
extended CLabel

### DIFF
--- a/src/types/api.jl
+++ b/src/types/api.jl
@@ -75,8 +75,8 @@ isensemble(m) = false
 
 doc_supervised_ml = """
     const XGLabel = Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
-    const CLabel  = Union{AbstractString,Integer,CategoricalValue}
-    const RLabel  = AbstractFloat
+    const CLabel  = Union{AbstractString, Symbol, CategoricalValue, Unsigned}
+    const RLabel  = Real
     const Label   = Union{CLabel,RLabel}
 
 Types for supervised machine learning labels (classification and regression).
@@ -85,7 +85,7 @@ Types for supervised machine learning labels (classification and regression).
 """$(doc_supervised_ml)"""
 const XGLabel = Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
 """$(doc_supervised_ml)"""
-const CLabel = Union{AbstractString, Symbol, CategoricalValue, UInt32}
+const CLabel = Union{AbstractString, Symbol, CategoricalValue, Unsigned}
 """$(doc_supervised_ml)"""
 const RLabel = Real
 """$(doc_supervised_ml)"""


### PR DESCRIPTION
Changed union types in CLabel:
originally it accepts only `UInt32` as `Unsigned` types, but since there's some models that uses `UInt8`
I extended types to `Unsigned`.